### PR TITLE
Always index when new dependency installed via composer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,10 +74,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
             { language: LanguageID, scheme: 'untitled' }
         ],
         synchronize: {
-            fileEvents: [
-                workspace.createFileSystemWatcher('**/composer.json'),
-                workspace.createFileSystemWatcher('**/vendor/**')
-            ]
+            fileEvents: workspace.createFileSystemWatcher('**/vendor/**')
         },
         initializationOptions: {
             storagePath: context.storagePath,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,13 @@ export async function activate(context: ExtensionContext): Promise<void> {
             { language: LanguageID, scheme: 'file' },
             { language: LanguageID, scheme: 'untitled' }
         ],
+        synchronize: {
+            fileEvents: [
+                workspace.createFileSystemWatcher('**/composer.json'),
+                workspace.createFileSystemWatcher('**/vendor/**'),
+                workspace.createFileSystemWatcher('**/*.php')
+            ]
+        },
         initializationOptions: {
             storagePath: context.storagePath,
             clearCache: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,8 +76,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         synchronize: {
             fileEvents: [
                 workspace.createFileSystemWatcher('**/composer.json'),
-                workspace.createFileSystemWatcher('**/vendor/**'),
-                workspace.createFileSystemWatcher('**/*.php')
+                workspace.createFileSystemWatcher('**/vendor/**')
             ]
         },
         initializationOptions: {


### PR DESCRIPTION
@marlonfan You must be implement system for watching all php files and give option to user for exclude some directories, files, this is hardcoded implementation, watch only root project, from subdirectories watching only vendor!

https://github.com/marlonfan/coc-phpls/commit/3f8327ac9a990a9c431a61aef626fa8b5afb7cc2#diff-f41e9d04a45c83f3b6f6e630f10117feL78
https://github.com/marlonfan/coc-phpls/commit/3f8327ac9a990a9c431a61aef626fa8b5afb7cc2#diff-f41e9d04a45c83f3b6f6e630f10117feL159