### PR TITLE
chore(intelephense): Update package and configuration from 1.3.6 -> 1.3.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,10 +168,52 @@
                     "description": "Global namespace constants and functions will be fully qualified (prefixed with a backslash).",
                     "scope": "window"
                 },
+                "intelephense.completion.triggerParameterHints": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Method and function completions will include parentheses and trigger parameter hints.",
+                    "scope": "window"
+                },
+                "intelephense.completion.maxItems": {
+                    "type": "number",
+                    "default": 100,
+                    "description": "The maximum number of completion items returned per request.",
+                    "scope": "window"
+                },
                 "intelephense.format.enable": {
                     "type": "boolean",
                     "default": true,
                     "description": "Enables formatting",
+                    "scope": "window"
+                },
+                "intelephense.telemetry.enabled": {
+                    "type": "boolean",
+                    "description": "Anonymous usage and crash data will be sent to Azure Application Insights.",
+                    "scope": "window",
+                    "default": null
+                },
+                "intelephense.rename.exclude": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [
+                        "**/vendor/**"
+                    ],
+                    "description": "Glob patterns to exclude files and folders from having symbols renamed. Rename operation will fail if references and/or definitions are found in excluded files/folders.",
+                    "scope": "resource"
+                },
+                "intelephense.environment.documentRoot": {
+                    "type": "string",
+                    "description": "The directory of the entry point to the application (index.php). Defaults to the first workspace folder. Used for resolving script inclusion.",
+                    "scope": "window"
+                },
+                "intelephense.environment.includePaths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The include paths (as individual path items) as defined in the include_path ini setting. Used for resolving script inclusion.",
                     "scope": "window"
                 },
                 "intelephense.trace.server": {
@@ -203,7 +245,7 @@
     },
     "dependencies": {
         "glob": "^7.1.4",
-        "intelephense": "^1.3.6",
+        "intelephense": "^1.3.11",
         "tslib": "^1.10.0",
         "vscode": "^1.1.36",
         "vscode-languageclient": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@ int64-buffer@^0.1.9:
   version "0.1.10"
   resolved "https://registry.yarnpkg.com/int64-buffer/-/int64-buffer-0.1.10.tgz#277b228a87d95ad777d07c13832022406a473423"
 
-intelephense@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/intelephense/-/intelephense-1.3.4.tgz#3b9fcf8741569f93b40a2f2ca27a5ee82097e814"
-  integrity sha512-hFchGpVS6eOKktS8k1mJa1FopGoquwbAfx0r6Wzl76Q5HFhTtrTCiJ2idEvAJQhEdO69hyg/mL/Xi65K8MvM6g==
+intelephense@^1.3.11:
+  version "1.3.11"
+  resolved "https://registry.yarnpkg.com/intelephense/-/intelephense-1.3.11.tgz#067d1d9d0c870f1d40a17cce76b519b72644e4bf"
+  integrity sha512-3pP/tdP4pEWFTm838sfJ5zjiFJHJDwTZcxvaKf6ZFP0Vnv+3ubjcUIjZzbnb3j68j3jMo5Q/2gWMWBCbO9KA3A==
   dependencies:
     "@bmewburn/js-beautify" "^1.10.4"
     "@bmewburn/turndown" "^5.0.3"
@@ -929,6 +929,7 @@ intelephense@^1.3.4:
     lru-cache "^5.1.1"
     micromatch "^4.0.2"
     protobufjs "~6.8.8"
+    request "^2.88.0"
     semver "^6.3.0"
     uuid "^3.3.2"
     vscode-jsonrpc "^4.1.0-next.2"


### PR DESCRIPTION
@marlonfan 

Thanks for this coc extention.

Updated the version of intelephense from 1.3.6 to `1.3.11`.

We also added the missing `"configuration"` based on `intelephense-docs`.