### PR TITLE
feat: Support for custom version of intelephense

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,8 @@ e.g:
 
 ## Configuration options
 
-* `phpls.enable` set to `false` to disable php language server.
+* `phpls.path`: Path to intelephense module, you can use a custom version of intelephense by modifying this setting to include the full path. e.g. `/path/to/node_modules/intelephens`. default: `""`
+* `phpls.enable`: Set to `false` to disable php language server. default: `true`
 
 ## Development
 

--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,7 @@ e.g:
 
 ## Configuration options
 
-* `phpls.path`: Path to intelephense module, you can use a custom version of intelephense by modifying this setting to include the full path. e.g. `/path/to/node_modules/intelephens`. default: `""`
+* `phpls.path`: Path to intelephense module, you can use a custom version of intelephense by modifying this setting to include the full path. e.g. `/path/to/node_modules/intelephense`. default: `""`
 * `phpls.enable`: Set to `false` to disable php language server. default: `true`
 
 ## Development

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
                 "phpls.path": {
                     "type": "string",
                     "default": "",
-                    "description": "lsp server path"
+                    "description": "Path to intelephense module, you can use a custom version of intelephense by modifying this setting to include the full path."
                 },
                 "phpls.enable": {
                     "type": "boolean",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
             file = require.resolve(config.path);
             if (file.endsWith("intelephense.js") === false) throw new Error();
 
-            /* ---- See :CocOpenlog ---- */
+            /* ---- See :CocOpenLog ---- */
             extensionContext.logger.info(
                 "intelephense module (phpls.path) is ready to be started"
             );
@@ -73,7 +73,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
             file = require.resolve("intelephense");
             if (file.endsWith("intelephense.js") === false) throw new Error();
 
-            /* ---- See :CocOpenlog ---- */
+            /* ---- See :CocOpenLog ---- */
             extensionContext.logger.info(
                 "intelephense module (builtin) is ready to be started"
             );


### PR DESCRIPTION
### Description

coc-phpls has a property called `phpls.path` in package.json, but it is not currently used in the implementation.

I've added the ability to use a custom version of intelephense using the properties of `phpls.path`.

Set the "module path" for `intelephense`. 

**e.g.** `/path/to/node_modules/intelephense`

This is an example of my actual setup.

```json
  "phpls.path": "/Users/yaegassy/.nodebrew/current/lib/node_modules/intelephense",
```

How do you feel about adding this feature?