### PR TITLE
Remove `Test,test` as it excludes valid classes

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
                         "**/.DS_Store/**",
                         "**/node_modules/**",
                         "**/bower_components/**",
-                        "**/vendor/**/{Test,test,Tests,tests}/**",
+                        "**/vendor/**/{Tests,tests}/**",
                         "**/.history/**",
                         "**/vendor/**/vendor/**"
                     ],


### PR DESCRIPTION
This has been changed upstream a while back ago: https://github.com/bmewburn/vscode-intelephense/blob/master/package.json#L137

It excluded valid classes like Symfony's WebTestCase.